### PR TITLE
Add list drivers rest

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/rest/StandaloneRestServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/rest/StandaloneRestServer.scala
@@ -62,6 +62,8 @@ private[deploy] class StandaloneRestServer(
     new StandaloneKillRequestServlet(masterEndpoint, masterConf)
   protected override val statusRequestServlet =
     new StandaloneStatusRequestServlet(masterEndpoint, masterConf)
+  protected override val listRequestServlet =
+    new StandaloneListRequestServlet(masterEndpoint, masterConf)
 }
 
 /**
@@ -101,6 +103,28 @@ private[rest] class StandaloneStatusRequestServlet(masterEndpoint: RpcEndpointRe
     d.workerHostPort = response.workerHostPort.orNull
     d.message = message.orNull
     d
+  }
+}
+
+/**
+ * A servlet for handling list requests passed to the [[StandaloneRestServer]].
+ */
+private[rest] class StandaloneListRequestServlet(masterEndpoint: RpcEndpointRef, conf: SparkConf)
+  extends ListQueuedDriversRequestServlet {
+
+  protected def handleList(): ListQueuedDriversResponse = {
+    // val response = masterEndpoint.askSync[DeployMessages.ListQueuedDriversResponse](
+    //  DeployMessages.RequestQueuedDriverList())
+    // val message = response.exception.map { s"Exception from the cluster:\n" + formatException(_) }
+    // val d = new SubmissionStatusResponse
+    // d.serverSparkVersion = sparkVersion
+    // d.submissionId = submissionId
+    // d.success = response.found
+    // d.driverState = response.state.map(_.toString).orNull
+    // d.workerId = response.workerId.orNull
+    // d.workerHostPort = response.workerHostPort.orNull
+    // d.message = message.orNull
+    new ListQueuedDriversResponse
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/deploy/rest/SubmitRestProtocolResponse.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/rest/SubmitRestProtocolResponse.scala
@@ -72,6 +72,17 @@ private[spark] class SubmissionStatusResponse extends SubmitRestProtocolResponse
 }
 
 /**
+ * A response to a list request in the REST application submission protocol.
+ */
+private[spark] class ListQueuedDriversResponse extends SubmitRestProtocolResponse {
+  var drivers: Array[Serializable] = null
+
+  protected override def doValidate(): Unit = {
+    super.doValidate()
+  }
+}
+
+/**
  * An error response message used in the REST application submission protocol.
  */
 private[rest] class ErrorResponse extends SubmitRestProtocolResponse {

--- a/core/src/test/scala/org/apache/spark/deploy/rest/StandaloneRestSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/rest/StandaloneRestSubmitSuite.scala
@@ -593,6 +593,7 @@ private class FaultyStandaloneRestServer(
   protected override val submitRequestServlet = new MalformedSubmitServlet
   protected override val killRequestServlet = new InvalidKillServlet
   protected override val statusRequestServlet = new ExplodingStatusServlet
+  protected override val listRequestServlet = new LimpingListServlet
 
   /** A faulty servlet that produces malformed responses. */
   class MalformedSubmitServlet
@@ -621,6 +622,16 @@ private class FaultyStandaloneRestServer(
       val s = super.handleStatus(submissionId)
       s.workerId = explode.toString
       s
+    }
+  }
+
+  /** A faulty list servlet that explodes. */
+  class LimpingListServlet extends StandaloneListRequestServlet(masterEndpoint, masterConf) {
+    private def explode: Int = 1 / 0
+    protected override def handleList(): ListQueuedDriversResponse = {
+      val ds = super.handleList()
+      ds.success = ( 0 == 0 )
+      ds
     }
   }
 }

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/mesos/MesosDriverDescription.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/mesos/MesosDriverDescription.scala
@@ -19,6 +19,7 @@ package org.apache.spark.deploy.mesos
 
 import java.util.Date
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import org.apache.spark.SparkConf
 import org.apache.spark.deploy.Command
 import org.apache.spark.scheduler.cluster.mesos.MesosClusterRetryState
@@ -41,13 +42,15 @@ private[spark] class MesosDriverDescription(
     val cores: Double,
     val supervise: Boolean,
     val command: Command,
-    schedulerProperties: Map[String, String],
+    val schedulerProperties: Map[String, String],
     val submissionId: String,
     val submissionDate: Date,
     val retryState: Option[MesosClusterRetryState] = None)
   extends Serializable {
 
+  @JsonIgnore
   val conf = new SparkConf(false)
+
   schedulerProperties.foreach {case (k, v) => conf.set(k, v)}
 
   def copy(

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/rest/mesos/MesosRestServer.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/deploy/rest/mesos/MesosRestServer.scala
@@ -50,6 +50,8 @@ private[spark] class MesosRestServer(
     new MesosKillRequestServlet(scheduler, masterConf)
   protected override val statusRequestServlet =
     new MesosStatusRequestServlet(scheduler, masterConf)
+  protected override val listRequestServlet =
+    new MesosListRequestServlet(scheduler, masterConf)
 }
 
 private[mesos] class MesosSubmitRequestServlet(
@@ -157,5 +159,14 @@ private[mesos] class MesosStatusRequestServlet(scheduler: MesosClusterScheduler,
     val d = scheduler.getDriverStatus(submissionId)
     d.serverSparkVersion = sparkVersion
     d
+  }
+}
+
+private[mesos] class MesosListRequestServlet(scheduler: MesosClusterScheduler, conf: SparkConf)
+  extends ListQueuedDriversRequestServlet {
+  protected override def handleList(): ListQueuedDriversResponse = {
+    val ds = scheduler.listQueuedDrivers()
+    ds.serverSparkVersion = sparkVersion
+    ds
   }
 }


### PR DESCRIPTION
## Problem statement

Information about queued drivers for making dynamic mesos agent scaling decisions is limited to html scraping as currently performed in spark-router.


## Solution

Expose existing driver information from the existing rest server.

## Additional Features 

- [ ] Add paging to limit+offset returned list of drivers.
- [ ] Implement for standalone cluster to allow avoiding html scraping. This is somewhat lower priority since html scraping works.

## Testing

[drivers.queued.txt](https://github.com/amperity/spark/files/2519775/drivers.queued.txt)

This file is from running a distribution build of this branch in my test mesos cluster running in aws-dev.