### PR TITLE
StringUtils: Add the correct string length, only when actually appending

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/StringUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/StringUtils.scala
@@ -117,8 +117,8 @@ object StringUtils extends Logging {
           val available = maxLength - length
           val stringToAppend = if (available >= sLen) s else s.substring(0, available)
           strings.append(stringToAppend)
+          length += stringToAppend.length
         }
-        length += sLen
       }
     }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/StringUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/StringUtilsSuite.scala
@@ -43,4 +43,12 @@ class StringUtilsSuite extends SparkFunSuite {
     assert(filterPattern(names, " a. ") === Seq("a1", "a2"))
     assert(filterPattern(names, " d* ") === Nil)
   }
+
+  test("StringConcat doesn't overflow on many inputs") {
+    val concat = new StringConcat(maxLength = 100)
+    0.to(Integer.MAX_VALUE).foreach { _ =>
+      concat.append("hello world")
+    }
+    assert(concat.toString.length === 100)
+  }
 }


### PR DESCRIPTION
We keep running into an issue with an apparent overflow before a `String.substring` call, resulting in trying to retrieve a substring with a negative index. It fails like this:

```
                 org.apache.spark.sql.execution.QueryExecution.$anonfun$toString$1     QueryExecution.scala:  221
                org.apache.spark.sql.catalyst.util.StringUtils$StringConcat.append        StringUtils.scala:  118
                                                        java.lang.String.substring              String.java: 1967
java.lang.StringIndexOutOfBoundsException: String index out of range: -2147418144
```

I can't see how this isn't a bug, but this is still present in apache/spark:

https://github.com/amperity/spark/blob/45cf5e99503b00a6bd83ea94d6d92761db1a00ab/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/StringUtils.scala#L113-L128

We attempt to append a string `s` to our string buffer, first checking that we have available space compared to our `maxLength`. Regardless of action taken (add the string fully, already at limit, add a substring), we would add the length of the string to our current internal `length` tracker - eventually this can overflow, even if we are no longer appending strings to our `ArrayBuffer` of `strings`.

This changes the logic to only increase the `length` when we make an append to that buffer, and only by the length of `stringToAppend` instead of the original string.

Added a unit test that was originally able to reproduce the problem.